### PR TITLE
FEATURE: COMMAND REGISTRY

### DIFF
--- a/lib/commando.rb
+++ b/lib/commando.rb
@@ -1,6 +1,8 @@
 
 require 'active_model'
 require 'virtus'
+
 require "commando/command"
+require "commando/registry"
 require "commando/version"
 

--- a/lib/commando/registry.rb
+++ b/lib/commando/registry.rb
@@ -1,0 +1,41 @@
+module Commando
+  class IAmACommandRegistry
+    def initialize(storage: DefaultStorageStrategy)
+      @storage = storage
+    end
+
+    def [](command)
+      handlers[storage_strategy.call command]
+    end
+
+  protected
+
+    def handlers
+      @handlers ||= {}
+    end
+
+    def storage_strategy
+      @storage ||= DefaultStorageStrategy
+    end
+
+    def register(command, handler: nil)
+      unless handler.nil?
+        handlers[storage_strategy.call command] = handler
+      end
+    end
+  end
+
+  DefaultStorageStrategy = ->(command) do
+    return command.class unless command.kind_of? Class
+    command
+  end
+
+  class NullHandler
+    def call(command)
+      puts "-" * 65
+      puts " NO HANDLER REGISTERED FOR #{command.class.upcase}"
+      puts "-" * 65
+      puts command.inspect
+    end
+  end
+end

--- a/test/lib/registry_test.rb
+++ b/test/lib/registry_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+module Commando
+  class IAmACommandRegistryTest < Minitest::Test
+    class WhenHandlerForCommandFoundInRegistry < IAmACommandRegistryTest
+      def subject
+        FakeCommandRegistry
+      end
+
+      def sut
+        @sut ||= subject.new
+      end
+      
+      def test_correct_handler_returned
+        assert_kind_of FakeHandler, sut[FakeCommand]
+        assert_kind_of FakeHandler, sut[FakeCommand.new]
+      end
+
+      class FakeCommandRegistry < IAmACommandRegistry
+        def initialize
+          register FakeCommand, handler: FakeHandler.new
+        end
+      end
+    end
+  end
+
+  class FakeCommand < IAmACommand
+    values do
+      integer :foo
+      string  :bar
+    end
+  end
+
+  class FakeHandler
+    def call(command) 
+    end
+  end
+end


### PR DESCRIPTION
Command registries are typically used to register a relationship between
a command value object and the handler used to execute changes.

This `IAmACommandRegistry` base class gives the necessary behavior to
command registries that inherit from to properly register handlers for
commands.