### PR TITLE
FEATURE: VALIDATIONS

### DIFF
--- a/lib/commando/command.rb
+++ b/lib/commando/command.rb
@@ -3,6 +3,10 @@ module Commando
     include Virtus.value_object
     include ActiveModel::Validations
 
+    def valid?
+      @valid ||= super
+    end
+
     def self.bool(value, options={})
       attribute value, Axiom::Types::Boolean, options
     end


### PR DESCRIPTION
Added an override to the `ActiveModel::Validations` method `valid?`.
The normal behavior to this behavior is to execute all of the validation
methods every time `valid?` is called.  Now `valid?` will execute once
regardless of how many times its called on an instance of a command.