### PR TITLE
BUG: DISPATCHER DISPATCHING MULTIPLE COMMANDS

### DIFF
--- a/lib/commando/dispatcher.rb
+++ b/lib/commando/dispatcher.rb
@@ -11,8 +11,8 @@ module Commando
       raise RegistryNotFound unless registry.present?
       raise UnknownCommand   unless command.kind_of? IAmACommand
 
-      yield response_of command, handler: registry.handler_for(command) if block_given?
-      response_of command, handler: registry.handler_for(command)
+      return response_of command, handler: registry.handler_for(command) unless block_given?
+      yield response_of command, handler: registry.handler_for(command)
     end
 
   private


### PR DESCRIPTION
Fixed an issue that was causing multiple commands to be dispatched when
passing a block to the dispatch method.