### PR TITLE
FEATURE: PLUGINS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # COMMANDO
 
-insert description here
+Commando is a project designed to help any ruby app use the command pattern to
+change state.
 
 ## PREREQUISITES
 * ruby-2.3.1
@@ -10,11 +11,34 @@ insert description here
 * ActiveModel::Validations
 
 ## INSTALLATION
+
 In your Gemfile
 
 ```
 gem 'commando', github: 'mdelkins/commando'
 ```
 
-## EXAMPLE
-example goes here
+## EXAMPLES
+
+1. [Command & Handler](./examples/command_and_handler.md)
+2. [Registry & Dispatcher](./examples/command_registry_and_dispatcher.md)
+
+## PLUGINS
+
+Commando uses a plugin system similar to
+[sequel](https://github.com/jeremyevans/sequel) or
+[roda](https://github.com/jeremyevans/roda) to extend the behavior of your
+command objects.  Currently their are two dependent plugins:
+
+* Commando::Plugins::VirtusPlugin
+* Commando::Plugins::ActiveModelPlugin
+
+### Commando::Plugins::VirtusPlugin
+
+This plugin injects the `Virtus.value_object` behavior into
+`Commando::IAmACommand` as well as a few helper methods for easily defining
+typed attributes.
+
+### Commando::Plugins::ActiveModelPlugin
+
+This plugin is used to give commands active model like validation behavior.

--- a/examples/command_and_handler.md
+++ b/examples/command_and_handler.md
@@ -1,0 +1,42 @@
+# COMMAND & HANDLER
+
+```ruby
+class RegisterAccountCommand < Commando::IAmACommand
+  values do
+    string :identity
+    string :password
+    string :password_confirmation
+  end
+
+  validates_presence_of \
+    :identity,
+    :password,
+    :password_confirmation
+
+  validate \
+    :password_confirmation!
+
+private
+  def password_confirmation!
+    unless password_confirmation == password
+      errors.add :password_confirmation, "doesn't match password"
+    end
+  end
+end
+
+class RegisterAccountHandler
+  def initialize(command)
+    @command = command 
+  end
+
+  def call
+    return command unless command.valid?
+    account_to_register = Account.new command.attributes
+    account_to_register.save!
+  end
+end
+
+command = RegisterAccountCommand.new identity: 'test@test.test', password: 'Password123123!@#', password_confirmation: 'Password123123!@#'
+handler = RegisterAccountHandler.new command
+handler.call
+```

--- a/examples/command_registry_and_dispatcher.md
+++ b/examples/command_registry_and_dispatcher.md
@@ -1,0 +1,56 @@
+```ruby
+class RegisterAccountCommand < Commando::IAmACommand
+  values do
+    string :identity
+    string :password
+    string :password_confirmation
+  end
+
+  validates_presence_of \
+    :identity,
+    :password,
+    :password_confirmation
+
+  validate \
+    :password_confirmation!
+
+private
+  def password_confirmation!
+    unless password_confirmation == password
+      errors.add :password_confirmation, "doesn't match password"
+    end
+  end
+end
+
+class RegisterAccountHandler
+  def initialize(command)
+    @command = command 
+  end
+
+  def call
+    return command unless command.valid?
+    account_to_register = Account.new command.attributes
+    account_to_register.save!
+  end
+end
+
+
+class AccountCommandRegistry < IAmACommandRegistry
+  def initialize
+    register RegisterAccountCommand, handler: RegisterAccountHandler
+  end
+end
+
+class AccountService
+  def initialize
+    @dispatcher = Commando::Dispatcher.new registry: AccountCommandRegistry.new
+  end
+
+  def register_account(safe_params)
+    dispatcher.dispatch RegisterAccountCommand.new safe_params
+  end
+
+private
+  attr_reader :dispatcher
+end
+```

--- a/lib/commando.rb
+++ b/lib/commando.rb
@@ -2,8 +2,12 @@
 require 'active_model'
 require 'virtus'
 
+require "commando/plugins/virtus_plugin"
+require "commando/plugins/activemodel_plugin"
+
 require "commando/command"
-require "commando/registry"
 require "commando/dispatcher"
+require "commando/registry"
+
 require "commando/version"
 

--- a/lib/commando/command.rb
+++ b/lib/commando/command.rb
@@ -1,42 +1,29 @@
 module Commando
   class IAmACommand
-    include Virtus.value_object
     include ActiveModel::Validations
 
-    def valid?
-      @valid ||= super
+    module ClassMethods
+      def use(plugin, *args, &block)
+        unless plugins.include? plugin
+          plugins << plugin
+          extend  plugin::ClassMethods    if plugin.const_defined? :ClassMethods
+          include plugin::InstanceMethods if plugin.const_defined? :InstanceMethods
+        end
+
+        self
+      end
+
+    private
+      def plugins
+        @@pluglins ||= []
+      end
     end
 
-    def self.bool(value, options={})
-      attribute value, Axiom::Types::Boolean, options
-    end
+    extend ClassMethods
 
-    def self.date(value, options={})
-      attribute value, Date, options
-    end
+    use self
+    use Plugins::VirtusPlugin
+    use Plugins::ActiveModelPlugin
 
-    def self.datetime(value, options={})
-      attribute value, DateTime, options
-    end
-
-    def self.decimal(value, options={})
-      attribute value, BigDecimal, options
-    end
-
-    def self.float(value, options={})
-      attribute value, Float, options
-    end
-
-    def self.integer(value, options={})
-      attribute value, Integer, options
-    end
-
-    def self.string(value, options={})
-      attribute value, String, options
-    end
-
-    def self.time(value, options={})
-      attribute value, Time, options
-    end
   end
 end

--- a/lib/commando/dispatcher.rb
+++ b/lib/commando/dispatcher.rb
@@ -11,18 +11,19 @@ module Commando
       raise RegistryNotFound unless registry.present?
       raise UnknownCommand   unless command.kind_of? IAmACommand
 
-      return response_of command, handler: registry.handler_for(command) unless block_given?
-      yield response_of command, handler: registry.handler_for(command)
+      registry.find_by command do |handler|
+        handler = handler.new command
+        result  = handler.call
+
+        if block_given?
+          yield result
+        end
+        
+        return result
+      end
     end
 
   private
     attr_reader :registry
-
-    def response_of(command, handler: nil)
-      handler ||= NullHanler
-
-      return command unless command.valid?
-      handler.call command
-    end
   end
 end

--- a/lib/commando/plugins/activemodel_plugin.rb
+++ b/lib/commando/plugins/activemodel_plugin.rb
@@ -1,0 +1,23 @@
+module Commando
+  module Plugins
+    module ActiveModelPlugin
+
+      module ClassMethods
+        def self.extended(object)
+          object.send(:include, ActiveModel::Validations)
+        end
+      end
+
+      module InstanceMethods
+        def valid?
+          @valid ||= super
+        end
+
+        def invalid?
+          not valid?
+        end
+      end
+
+    end
+  end
+end

--- a/lib/commando/plugins/virtus_plugin.rb
+++ b/lib/commando/plugins/virtus_plugin.rb
@@ -1,0 +1,47 @@
+module Commando
+  module Plugins
+    module VirtusPlugin
+
+      module ClassMethods
+        def self.extended(object)
+          object.send(:include, Virtus.value_object)
+        end
+
+        def bool(value, options={})
+          attribute value, Axiom::Types::Boolean, options
+        end
+
+        def date(value, options={})
+          attribute value, Date, options
+        end
+
+        def datetime(value, options={})
+          attribute value, DateTime, options
+        end
+
+        def decimal(value, options={})
+          attribute value, BigDecimal, options
+        end
+
+        def float(value, options={})
+          attribute value, Float, options
+        end
+
+        def integer(value, options={})
+          attribute value, Integer, options
+        end
+
+        def string(value, options={})
+          attribute value, String, options
+        end
+
+        def time(value, options={})
+          attribute value, Time, options
+        end
+      end
+
+      module InstanceMethods
+      end
+    end
+  end
+end

--- a/lib/commando/registry.rb
+++ b/lib/commando/registry.rb
@@ -5,12 +5,12 @@ module Commando
     end
 
     def [](command)
-      handlers[storage_strategy.call command].tap do |handler|
+      handlers.fetch(storage_strategy.call command) { NullHandler }.tap do |handler|
         yield handler if block_given?
       end
     end
 
-    alias_method :handler_for, :[]
+    alias_method :find_by, :[]
 
   protected
 
@@ -35,11 +35,18 @@ module Commando
   end
 
   class NullHandler
-    def call(command)
+    def initialize(command)
+      @command = command
+    end
+
+    def call
       puts "-" * 65
       puts " NO HANDLER REGISTERED FOR #{command.class.upcase}"
       puts "-" * 65
       puts command.inspect
     end
+
+  private
+    attr_reader :command
   end
 end

--- a/test/commando/registry_test.rb
+++ b/test/commando/registry_test.rb
@@ -2,18 +2,24 @@ require 'test_helper'
 
 module Commando
   class IAmACommandRegistryTest < Minitest::Test
-    class WhenHandlerForCommandFoundInRegistry < IAmACommandRegistryTest
-      def subject
-        FakeCommandRegistry
-      end
+    def subject
+      FakeCommandRegistry
+    end
 
-      def sut
-        @sut ||= subject.new
-      end
-      
+    def sut
+      @sut ||= subject.new
+    end
+
+    class WhenHandlerForCommandFoundInRegistry < IAmACommandRegistryTest
       def test_correct_handler_returned
-        assert_kind_of FakeHandler, sut[FakeCommand]
-        assert_kind_of FakeHandler, sut[FakeCommand.new]
+        assert_equal FakeHandler, sut[FakeCommand]
+        assert_equal FakeHandler, sut[FakeCommand.new]
+      end
+    end
+
+    class WhenHandlerForCommandNotFoundInRegistry < IAmACommandRegistryTest
+      def test_null_handler_returned
+        assert_equal NullHandler, sut[:foo]
       end
     end
   end

--- a/test/fixtures/fake_handler.rb
+++ b/test/fixtures/fake_handler.rb
@@ -1,7 +1,15 @@
 module Commando
   class FakeHandler
-    def call(command)
+    def initialize(command)
+      @command = command
+    end
+
+    def call
+      return command unless command.valid?
       true
     end
+
+  private
+    attr_reader :command
   end
 end

--- a/test/fixtures/fake_plugin.rb
+++ b/test/fixtures/fake_plugin.rb
@@ -1,0 +1,17 @@
+module Commando
+  module Plugins
+    module FakePlugin
+      module ClassMethods
+        def new_class_behavior?
+          true
+        end
+      end
+
+      module InstanceMethods
+        def new_instance_behavior?
+          true
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/fake_registry.rb
+++ b/test/fixtures/fake_registry.rb
@@ -1,7 +1,7 @@
 module Commando
   class FakeCommandRegistry < IAmACommandRegistry
     def initialize
-      register FakeCommand, handler: FakeHandler.new
+      register FakeCommand, handler: FakeHandler
     end
   end
 end

--- a/test/plugins_test.rb
+++ b/test/plugins_test.rb
@@ -1,0 +1,33 @@
+module Commando
+  class PluginTest < Minitest::Test
+    def subject
+      Plugins::FakePlugin
+    end
+
+    class WhenUsingAPlugin < PluginTest
+      def setup
+        FakeCommand.use subject
+      end
+
+      class AndPluginHasInstanceBehavior < WhenUsingAPlugin
+        def sut
+          @sut ||= FakeCommand.new
+        end
+
+         def test_behavior_acquired
+           assert sut.new_instance_behavior?
+         end
+      end
+
+      class AndPluginHasClassBehavior < WhenUsingAPlugin
+        def sut
+          @sut ||= FakeCommand
+        end
+
+        def test_behavior_acquired
+          assert sut.new_class_behavior?
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'commando'
 
 require_relative './fixtures/fake_command'
 require_relative './fixtures/fake_handler'
+require_relative './fixtures/fake_plugin'
 require_relative './fixtures/fake_registry'
 
 require 'minitest/color'


### PR DESCRIPTION
This feature for the `IAmACommand` class will allow users of the gem to
create custom plugins to inject new behaviors.  Not only will this give each
user the ability to tailor Commando commands to their exact needs, but
also this will allow the project to remove the dependencies on `Virtus` and
`ActiveModel` and move those to separate plugin gems.