### PR TITLE
REFACTOR: DEPRICATE ACTIVEMODEL

### DIFF
--- a/commandoes.gemspec
+++ b/commandoes.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activemodel", "~> 5.0"
-
   spec.add_development_dependency "bump",    "~> 0.5"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/commandoes.rb
+++ b/lib/commandoes.rb
@@ -1,11 +1,5 @@
-
-require 'active_model'
-
-require "commandoes/plugins/activemodel_plugin"
-
 require "commandoes/command"
 require "commandoes/dispatcher"
 require "commandoes/registry"
-
 require "commandoes/version"
 

--- a/lib/commandoes/command.rb
+++ b/lib/commandoes/command.rb
@@ -1,7 +1,5 @@
 module Commandoes
   class IAmACommand
-    include ActiveModel::Validations
-
     module ClassMethods
       def use(plugin, *args, &block)
         unless plugins.include? plugin
@@ -20,8 +18,6 @@ module Commandoes
     end
 
     extend ClassMethods
-
     use self
-    use Plugins::ActiveModelPlugin
   end
 end

--- a/lib/commandoes/dispatcher.rb
+++ b/lib/commandoes/dispatcher.rb
@@ -8,7 +8,7 @@ module Commandoes
     end
 
     def dispatch(command)
-      raise RegistryNotFound unless registry.present?
+      raise RegistryNotFound if registry.nil?
       raise UnknownCommand   unless command.kind_of? IAmACommand
 
       registry.find_by command do |handler|

--- a/test/dispatcher_test.rb
+++ b/test/dispatcher_test.rb
@@ -33,16 +33,6 @@ module Commandoes
           end
         end
 
-        class AndCommandIsNotValid < WithARegistry
-          def command
-            @command ||= FakeCommand.new
-          end
-
-          def test_response_is_correct
-            assert_equal command, sut.dispatch(command)
-          end
-        end
-
         class AndCommandIsValid < WithARegistry
           def command
             @command ||= FakeCommand.new foo: :abc

--- a/test/fixtures/fake_command.rb
+++ b/test/fixtures/fake_command.rb
@@ -6,8 +6,5 @@ module Commandoes
       @foo = foo
       @bar = bar
     end
-
-    validates_presence_of \
-      :foo
   end
 end

--- a/test/fixtures/fake_handler.rb
+++ b/test/fixtures/fake_handler.rb
@@ -5,7 +5,6 @@ module Commandoes
     end
 
     def call
-      return command unless command.valid?
       true
     end
 


### PR DESCRIPTION
Now that the plugin system is in place, we can move the dependency on
activemodel to a separate gem.